### PR TITLE
chore: use make docker-build to reproducible build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,4 +122,9 @@ schemas:
 	moleculec --language rust --schema-file schemas/rgbpp.mol > crates/core/src/schemas/rgbpp.rs
 	cargo fmt
 
-.PHONY: build test check clippy fmt cargo clean prepare checksum schemas
+# Docker reproducible build
+docker-build:
+	docker run --rm -v `pwd`:/code   docker.io/xxuejie/rust-n-llvm@sha256:71e98a25eb0350c779cdea18c296d101c4ddc375b8fd96531b63f3105ca64ca2   bash -c "cd /code; make checksum MODE=release CHECKSUM_FILE=checksums.txt"
+	sha256sum -c checksums.txt
+
+.PHONY: build test check clippy fmt cargo clean prepare checksum schemas docker-build

--- a/checksums.txt
+++ b/checksums.txt
@@ -1,0 +1,2 @@
+875670adc22ee74985f6b37980795c177fb2e2a765e919c542f80138858f6f5a  build/release/btc-time-lock
+ecd325087d56f2880b3b006e1a9583ddcaa3fe4e09c14fe7f3ed39eb0cabba50  build/release/rgbpp-lock


### PR DESCRIPTION
Use `make docker-build` to do reproducible build.