### PR TITLE
fix: bitcoin transaction encoding in little endian

### DIFF
--- a/crates/core/src/bitcoin/encoder.rs
+++ b/crates/core/src/bitcoin/encoder.rs
@@ -18,13 +18,13 @@ impl Encoder {
     pub fn put_var_int(&mut self, n: usize) {
         if n > 0xFFFFFFFF {
             self.buf.put_u8(0xFF);
-            self.buf.put_u64(n as u64);
+            self.buf.put_u64_le(n as u64);
         } else if n > 0xFFFF {
             self.buf.put_u8(0xFE);
-            self.buf.put_u32(n as u32);
+            self.buf.put_u32_le(n as u32);
         } else if n > 0xFD {
             self.buf.put_u8(0xFD);
-            self.buf.put_u16(n as u16);
+            self.buf.put_u16_le(n as u16);
         } else {
             self.buf.put_u8(n as u8);
         }
@@ -37,15 +37,15 @@ impl Encoder {
             sequence,
         } = txin;
         self.buf.put_slice(txid.as_slice());
-        self.buf.put_u32(*vout);
+        self.buf.put_u32_le(*vout);
         self.put_var_int(script.len());
         self.buf.put_slice(script);
-        self.buf.put_u32(*sequence);
+        self.buf.put_u32_le(*sequence);
     }
 
     pub fn put_txout(&mut self, txout: &TxOut) {
         let TxOut { value, script } = txout;
-        self.buf.put_i64(*value);
+        self.buf.put_i64_le(*value);
         self.put_var_int(script.len());
         self.buf.put_slice(script);
     }
@@ -60,7 +60,7 @@ pub fn encode_btc_tx(btc_tx: BTCTx) -> Bytes {
         lock_time,
     } = btc_tx;
     let mut encoder = Encoder::new();
-    encoder.buf.put_u32(version);
+    encoder.buf.put_u32_le(version);
     encoder.put_var_int(inputs.len());
 
     for input in inputs.iter() {
@@ -72,6 +72,6 @@ pub fn encode_btc_tx(btc_tx: BTCTx) -> Bytes {
     for output in outputs.iter() {
         encoder.put_txout(output);
     }
-    encoder.buf.put_u32(lock_time);
+    encoder.buf.put_u32_le(lock_time);
     encoder.buf.freeze()
 }


### PR DESCRIPTION
Bitcoin encoder module is used for testing purpose, this feature is not enabled in both `rgbpp` and `btc time lock`
 contracts, so it won't affect the contracts.

* https://github.com/ckb-cell/rgbpp/blob/main/crates/core/src/bitcoin/mod.rs#L2
* https://github.com/ckb-cell/rgbpp/blob/main/crates/core/Cargo.toml#L9